### PR TITLE
Support multiple selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Change Case Obsidian Plugin
 
-Plugin to let you change the case (UPPER CASE, camelCase, snake_case, etc) of the current selection.
+Plugin to let you change the case (UPPER CASE, camelCase, snake_case, etc) of the selected text.
 
 This is a plugin for Obsidian (https://obsidian.md).
 
@@ -19,3 +19,7 @@ This plugin adds the following commands:
 - `Change Case: path/case`
 - `Change Case: Sentence case`
 - `Change Case: snake_case`
+
+It also adds the command `Change Case: Select from list`. This will present a selection modal with the options listed above. This is easier to use on mobile.
+
+These commands can be used with multiple selections.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,25 +20,24 @@ export interface ChangeCaseCommand {
 	fn: (str: string) => string;
 }
 
-export const commands = (): ChangeCaseCommand[] =>
-	[
-		{ id: "lower", fn: lowerCase },
-		{ id: "upper", fn: upperCase },
-		{ id: "camel", fn: camelCase },
-		{ id: "capital", fn: capitalCase },
-		{ id: "constant", fn: constantCase },
-		{ id: "dot", fn: dotCase },
-		{ id: "header", fn: headerCase },
-		{ id: "no", fn: noCase },
-		{ id: "param", fn: paramCase },
-		{ id: "pascal", fn: pascalCase },
-		{ id: "path", fn: pathCase },
-		{ id: "sentence", fn: sentenceCase },
-		{ id: "snake", fn: snakeCase },
-	].map(({ id, fn }) => {
-		return {
-			id,
-			name: fn(id + " case"),
-			fn,
-		};
-	});
+export const commands: ChangeCaseCommand[] = [
+	{ id: "lower", fn: lowerCase },
+	{ id: "upper", fn: upperCase },
+	{ id: "camel", fn: camelCase },
+	{ id: "capital", fn: capitalCase },
+	{ id: "constant", fn: constantCase },
+	{ id: "dot", fn: dotCase },
+	{ id: "header", fn: headerCase },
+	{ id: "no", fn: noCase },
+	{ id: "param", fn: paramCase },
+	{ id: "pascal", fn: pascalCase },
+	{ id: "path", fn: pathCase },
+	{ id: "sentence", fn: sentenceCase },
+	{ id: "snake", fn: snakeCase },
+].map(({ id, fn }) => {
+	return {
+		id,
+		name: fn(id + " case"),
+		fn,
+	};
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,85 @@
-import { Editor, Plugin } from "obsidian";
-import { commands } from "./commands";
+import {
+	App,
+	Editor,
+	EditorPosition,
+	EditorSelection,
+	FuzzySuggestModal,
+	Plugin,
+} from "obsidian";
+import { ChangeCaseCommand, commands } from "./commands";
+
+function normalizeSelection({
+	anchor,
+	head,
+}: EditorSelection): [from: EditorPosition, to: EditorPosition] {
+	if (anchor.line < head.line) {
+		return [anchor, head];
+	}
+	if (anchor.line > head.line) {
+		return [head, anchor];
+	}
+	if (anchor.ch < head.ch) {
+		return [anchor, head];
+	}
+	return [head, anchor];
+}
+
+function replaceAllSelections(
+	editor: Editor,
+	fn: (str: string) => string
+): void {
+	if (editor.somethingSelected()) {
+		editor.transaction({
+			changes: editor.listSelections().map((selection) => {
+				const [from, to] = normalizeSelection(selection);
+				const str = editor.getRange(from, to);
+				return { from, to, text: fn(str) };
+			}),
+		});
+	}
+}
+
+class SelectCaseModal extends FuzzySuggestModal<ChangeCaseCommand> {
+	private _editor: Editor;
+
+	constructor(app: App, editor: Editor) {
+		super(app);
+		this._editor = editor;
+	}
+
+	getItems(): ChangeCaseCommand[] {
+		return commands;
+	}
+
+	getItemText(cmd: ChangeCaseCommand): string {
+		return cmd.name;
+	}
+
+	onChooseItem(cmd: ChangeCaseCommand) {
+		replaceAllSelections(this._editor, cmd.fn);
+	}
+}
 
 export default class ChangeCasePlugin extends Plugin {
 	async onload() {
-		for (const { id, name, fn } of commands()) {
+		this.addCommand({
+			id: "select",
+			name: "Select from list",
+			icon: "case-sensitive",
+			editorCallback: (editor: Editor): void => {
+				const modal = new SelectCaseModal(this.app, editor);
+				modal.setPlaceholder("Choose a format for the selection");
+				modal.open();
+			},
+		});
+
+		for (const { id, name, fn } of commands) {
 			this.addCommand({
 				id,
 				name,
+				icon: "case-sensitive",
 				editorCallback: (editor: Editor): void => {
-					editor.replaceSelection(fn(editor.getSelection()));
+					replaceAllSelections(editor, fn);
 				},
 			});
 		}

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { ChangeCaseCommand, commands } from "../src/commands";
 
 const commands_map = new Map<string, ChangeCaseCommand>(
-	commands().map((cmd) => [cmd.id, cmd])
+	commands.map((cmd) => [cmd.id, cmd])
 );
 
 const tested_command_ids = new Set<string>();


### PR DESCRIPTION
- Support multiple selections. All selections will be processed in a single transaction so that undo works as expected.
- Add command `Change Case: Select from list`. This will present a selection modal. This is easier to use on mobile.
- Add an icon to the commands.