### PR TITLE
chore: fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"semantic-release": "semantic-release",
-		"test": "node --loader tsx --test ./test/index.mts"
+		"test": "find ./test -type f -name '*.test.mts' | xargs node --import tsx/esm --test"
 	},
 	"keywords": [],
 	"author": "David Brockman",

--- a/test/index.mts
+++ b/test/index.mts
@@ -1,1 +1,0 @@
-import "./commands.test.mjs";


### PR DESCRIPTION
tsx must be loaded with --import instead of --loader
The --loader flag was deprecated in Node v20.6.0 and v18.19.0
