### PR TITLE
ci: use node 20 and run semantic-release on PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,12 +16,11 @@ jobs:
           version: 8
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm run test
-      - run: pnpm run semantic-release
+      - run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.ref == 'refs/heads/master'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+	"branches": ["master"],
 	"tagFormat": "${version}",
 	"plugins": [
 		[

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
-		"semantic-release": "semantic-release",
 		"test": "find ./test -type f -name '*.test.mts' | xargs node --import tsx/esm --test"
 	},
 	"keywords": [],
@@ -30,7 +29,7 @@
 		"typescript": "^5.3.3"
 	},
 	"engines": {
-		"node": ">=18",
+		"node": ">=20",
 		"pnpm": ">=8"
 	},
 	"repository": {


### PR DESCRIPTION
Running semantic-release on PRs should hopefully catch issues before the PR is merged. It will only do actual releases on the master branch.