### PR TITLE
fix: preserve punctuation in sentence and capital case commands

### DIFF
--- a/src/commands.mts
+++ b/src/commands.mts
@@ -1,7 +1,6 @@
 import {
 	Case,
 	camelCase,
-	capitalCase,
 	constantCase,
 	dotCase,
 	kebabCase,
@@ -9,10 +8,42 @@ import {
 	pascalCase,
 	pascalSnakeCase,
 	pathCase,
-	sentenceCase,
 	snakeCase,
 	trainCase,
 } from "change-case";
+
+// Matches a word: a letter/digit followed by more letters/digits/apostrophes.
+// Apostrophes (ASCII and Unicode curly) are kept as part of the word.
+const WORD_RE = /[\p{L}\d][\p{L}\d'\u2019]*/gu;
+
+// Prose-aware sentence case: uppercase first word, lowercase the rest,
+// preserving all punctuation and whitespace in place.
+const proseSentenceCase: Case = (input, options) => {
+	const locale = options?.locale || undefined;
+	let first = true;
+	return input.replace(WORD_RE, (word) => {
+		if (first) {
+			first = false;
+			return (
+				word.charAt(0).toLocaleUpperCase(locale) +
+				word.slice(1).toLocaleLowerCase(locale)
+			);
+		}
+		return word.toLocaleLowerCase(locale);
+	});
+};
+
+// Prose-aware capital case: uppercase first letter of every word,
+// preserving all punctuation and whitespace in place.
+const proseCapitalCase: Case = (input, options) => {
+	const locale = options?.locale || undefined;
+	return input.replace(
+		WORD_RE,
+		(word) =>
+			word.charAt(0).toLocaleUpperCase(locale) +
+			word.slice(1).toLocaleLowerCase(locale),
+	);
+};
 
 export type CmdFn = (str: string, options?: { locale?: string }) => string;
 
@@ -32,7 +63,7 @@ export const commands = [
 	wrap("lower", (s, o) => s.toLocaleLowerCase(o?.locale || undefined)),
 	wrap("upper", (s, o) => s.toLocaleUpperCase(o?.locale || undefined)),
 	wrap("camel", camelCase),
-	wrap("capital", capitalCase),
+	wrap("capital", proseCapitalCase),
 	wrap("constant", constantCase),
 	wrap("dot", dotCase),
 	wrap("kebab", kebabCase),
@@ -40,7 +71,7 @@ export const commands = [
 	wrap("pascal", pascalCase),
 	wrap("pascalSnake", pascalSnakeCase),
 	wrap("path", pathCase),
-	wrap("sentence", sentenceCase),
+	wrap("sentence", proseSentenceCase),
 	wrap("snake", snakeCase),
 	wrap("train", trainCase),
 ];

--- a/test/commands.test.mts
+++ b/test/commands.test.mts
@@ -59,9 +59,12 @@ test("capital case", () => {
 	assert.strictEqual(name, "Capital Case");
 	assert.strictEqual(fn("", { locale }), "");
 	assert.strictEqual(fn("test string", { locale }), "Test String");
-	assert.strictEqual(fn("test_string", { locale }), "Test String");
-	assert.strictEqual(fn("testString", { locale }), "Test String");
+	assert.strictEqual(fn("test_string", { locale }), "Test_String");
+	assert.strictEqual(fn("testString", { locale }), "Teststring");
 	assert.strictEqual(fn("Test String", { locale }), "Test String");
+	assert.strictEqual(fn("it's a test", { locale }), "It's A Test");
+	assert.strictEqual(fn("James - sit down", { locale }), "James - Sit Down");
+	assert.strictEqual(fn("hello, world!", { locale }), "Hello, World!");
 });
 
 test("constant case", () => {
@@ -155,9 +158,13 @@ test("sentence case", () => {
 	assert.strictEqual(name, "Sentence case");
 	assert.strictEqual(fn("", { locale }), "");
 	assert.strictEqual(fn("Test string", { locale }), "Test string");
-	assert.strictEqual(fn("testString", { locale }), "Test string");
+	assert.strictEqual(fn("testString", { locale }), "Teststring");
 	assert.strictEqual(fn("TEST STRING", { locale }), "Test string");
-	assert.strictEqual(fn("test_string", { locale }), "Test string");
+	assert.strictEqual(fn("test_string", { locale }), "Test_string");
+	assert.strictEqual(fn("IT'S", { locale }), "It's");
+	assert.strictEqual(fn("don't stop", { locale }), "Don't stop");
+	assert.strictEqual(fn("James - sit down", { locale }), "James - sit down");
+	assert.strictEqual(fn("hello, world!", { locale }), "Hello, world!");
 });
 
 test("snake case", () => {


### PR DESCRIPTION
## Summary

Fixes #159

The `change-case` library's `split()` function uses a regex (`/[^\p{L}\d]+/giu`) that strips **all** non-letter/non-digit characters, including apostrophes, hyphens, commas, and other punctuation. This is correct for programmatic identifier conversion (camelCase, snake_case, etc.) but wrong for prose-oriented commands like **Sentence case** and **Capital case**.

**Before:** `IT'S` → `It s`, `don't stop` → `Don t stop`, `James - sit down` → `James Sit Down`  
**After:** `IT'S` → `It's`, `don't stop` → `Don't stop`, `James - sit down` → `James - sit down`

## Approach

Replaced the `change-case` library's `sentenceCase` and `capitalCase` with prose-aware implementations that use `String.replace()` with a word-matching regex. These functions only transform letter casing and leave all punctuation, whitespace, and special characters exactly in place.

The word regex (`/[\p{L}\d][\p{L}\d'\u2019]*/gu`) treats apostrophes (both ASCII `'` and Unicode curly `'`) as part of words, so contractions like `it's` and `don't` are handled as single tokens.

All other commands (camel, snake, kebab, constant, dot, no, pascal, pascalSnake, path, train, lower, upper) are unchanged.

## Tradeoff

`sentence` and `capital` no longer split on camelCase boundaries or programmatic delimiters (`_`, `.`). For example, `testString` → `Teststring` instead of `Test string`. This is the correct behaviour for a note-taking app — users applying sentence/capital case are working with prose. The programmatic commands handle identifier conversion.

## Test plan

- [x] Updated existing test assertions for changed behaviour
- [x] Added new test cases for apostrophes, hyphens, commas, and exclamation marks
- [x] All 15 tests pass
- [x] Plugin builds successfully
- [x] Tested in Obsidian (manual)